### PR TITLE
fixing: Because easy_localization_loader >=0.0.1 depends on xml ^3.5.…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   http: ^0.12.0+2
   csv: ^4.0.3
   yaml: ^2.2.0
-  xml: ^3.5.0
+  xml: ^4.1.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
…0 and flutter_svg 0.18.0 depends on xml ^4.1.0, easy_localization_loader >=0.0.1 is incompatible with flutter_svg 0.18.0. So, because qanuni_mobile_app depends on both flutter_svg 0.18.0 and easy_localization_loader 0.0.2, version solving failed.