### PR TITLE
fix: if inside string ignore text-delimiters

### DIFF
--- a/lib/src/csv_asset_loader.dart
+++ b/lib/src/csv_asset_loader.dart
@@ -11,12 +11,20 @@ import 'package:flutter/services.dart';
 //
 class CsvAssetLoader extends AssetLoader {
   CSVParser? csvParser;
+  final bool useAutodetect;
+
+  CsvAssetLoader({
+    this.useAutodetect = true,
+  });
 
   @override
   Future<Map<String, dynamic>> load(String path, Locale locale) async {
     if (csvParser == null) {
       log('easy localization loader: load csv file $path');
-      csvParser = CSVParser(await rootBundle.loadString(path));
+      csvParser = CSVParser(
+        await rootBundle.loadString(path),
+        useAutodetect: useAutodetect,
+      );
     } else {
       log('easy localization loader: CSV parser already loaded, read cache');
     }
@@ -51,7 +59,7 @@ class CSVParser {
     this.csvString, {
     this.fieldDelimiter,
     this.eol,
-    this.useAutodetect = false,
+    this.useAutodetect = true,
   }) : lines = CsvToListConverter().convert(
           csvString,
           fieldDelimiter: fieldDelimiter,

--- a/lib/src/csv_asset_loader.dart
+++ b/lib/src/csv_asset_loader.dart
@@ -51,7 +51,7 @@ class CSVParser {
     this.csvString, {
     this.fieldDelimiter,
     this.eol,
-    this.useAutodetect = true,
+    this.useAutodetect = false,
   }) : lines = CsvToListConverter().convert(
           csvString,
           fieldDelimiter: fieldDelimiter,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   connectivity_plus: ^5.0.1
-  csv: ^5.0.1
+  csv: ^6.0.0
   easy_localization: ^3.0.3
   flutter: { sdk: flutter }
   http: ^1.1.0

--- a/test/easy_localization_loader_test.dart
+++ b/test/easy_localization_loader_test.dart
@@ -13,6 +13,8 @@ void main() {
           'str\ten_US\t$localeName\r\nscreen_language\tInterface language\tЯзык интерфейса\r\n';
       const testCommaCRLFString =
           'str,en_US,$localeName\r\nscreen_language,Interface language,Язык интерфейса\r\n';
+      const testCommaQuotesInsideCRLFString =
+          'str,en_US,$localeName\r\nscreen_language,"Interface language, Test","Язык интерфейса, Тест"\r\n';
 
       Map<String, dynamic> getResult(
         String testString,
@@ -44,6 +46,11 @@ void main() {
         'testCommaCRLFString'.toUpperCase(),
         {'screen_language': 'Язык интерфейса'},
         getResult(testCommaCRLFString, localeName),
+      );
+      output(
+        'testCommaQuotesInsideCRLFString'.toUpperCase(),
+        {'screen_language': 'Язык интерфейса, Тест'},
+        getResult(testCommaQuotesInsideCRLFString, localeName, false),
       );
       output(
         'testTabLFString, autodetect = false'.toUpperCase(),


### PR DESCRIPTION
Update CSV to latest version which fixes issue #https://github.com/close2/csv/issues/70. and made one default value 'useAutodetect' to false to make it work.

### **Description:**

-  From CSV Library Issue: (https://github.com/close2/csv/commit/a6856fb7e90684518378f192d0d6da0bc5c21875)

> If inside an unquoted string, text-delimiters are ignored instead of swallowed.
> This (partially?) fixes issue https://github.com/close2/csv/issues/70.
> Example: `"A B", "C, D"` will now produce `[["A B",' "C',' D"']]` instead of `[["A B",' C',' D']]`.
> 

- My Usecase:

I had a line containing a comma (,) inside "" in the langs.csv locale file
Example: 
`contact_info,"Send mail, suggestion or feedback",إرسال بريد، اقتراح أو ملاحظات,"Məktub, təklif və ya rəy göndərin","ইমেল, পরামর্শ বা প্রতিক্রিয়া পাঠান","Mail, Vorschlag oder Feedback senden","Envoyer un courriel, une suggestion ou un retour d'utilisation","Kirim surat, saran atau masukan","Invia mail, suggerimenti o feedback","Hantar surat, cadangan atau maklum balas","Отправить письмо, предложение или отзыв","Posta, öneri veya geri bildirim gönderin",ای‌میل، تجاویز، مشورہ بھیجیں
`

Here in my app, it was rendering only ["Send mail] and missing the next part of [, suggestion or feedback] as both are separated by comma. After some research I found this issue is already fixed by CSV library in latest version. So I updated CSV to latest here and made 1 change according to it.
