### PR TITLE
feat: create combination_loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [x] XML (XmlAssetLoader, XmlSingleAssetLoader)
 - [x] Yaml (YamlAssetLoader, YamlSingleAssetLoader)
 - [x] FILE (FileAssetLoader)
+- [x] Combination (CombinationLoader)
 
 ### Configuration
 

--- a/lib/easy_localization_loader.dart
+++ b/lib/easy_localization_loader.dart
@@ -6,3 +6,4 @@ export 'package:easy_localization_loader/src/smart_network_asset_loader.dart';
 export 'package:easy_localization_loader/src/tests_asset_loader.dart';
 export 'package:easy_localization_loader/src/xml_asset_loader.dart';
 export 'package:easy_localization_loader/src/yaml_asset_loader.dart';
+export 'package:easy_localization_loader/src/combination_loader.dart';

--- a/lib/src/combination_loader.dart
+++ b/lib/src/combination_loader.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import 'package:easy_localization/easy_localization.dart';
+
+class CombinationLoader extends AssetLoader {
+  const CombinationLoader({required this.loaders});
+
+  final List<AssetLoader> loaders;
+
+  @override
+  Future<Map<String, dynamic>> load(String path, Locale locale) async {
+    final resultFutures = loaders.map((loader) async {
+      try {
+        return loader.load(path, locale);
+      } catch (error) {
+        debugPrint(error.toString());
+        return {};
+      }
+    });
+
+    try {
+      final results = await Future.wait(resultFutures);
+      return results.fold<Map<String, dynamic>>(
+        {},
+        (prev, e) => {...prev, ...(e ?? {})},
+      );
+    } catch (error) {
+      debugPrint(error.toString());
+      return {};
+    }
+  }
+}


### PR DESCRIPTION
Problem: We may need to combine many loaders from many sources and get a final result. So I created `combination_loader` to help combine a list of loaders like `RootBundleAssetLoader`, `HttpAssetLoader`, and so on.

To apply it, we use it simply by putting it as a loader in `EasyLocalization` widget.

```
...
EasyLocalization(
  child: MyApp(),
  supportedLocales: [
    Locale('en', 'US'),
    Locale('ar', 'DZ'),
  ],
  assetLoader: CombinationLoader(
    loaders: [
      RootBundleAssetLoader(...),
      HttpAssetLoader(...),
    ]
  )
)
...
```



