### PR TITLE
ci: Updated the linter from pedantic to flutter_lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,2 @@
 #https://dart.dev/guides/language/analysis-options
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml

--- a/lib/src/smart_network_asset_loader.dart
+++ b/lib/src/smart_network_asset_loader.dart
@@ -54,8 +54,7 @@ class SmartNetworkAssetLoader extends AssetLoader {
 
     // still nothing? Load from assets
     if (string == '') {
-      string = await rootBundle
-          .loadString(assetsPath + '/' + locale.toString() + '.json');
+      string = await rootBundle.loadString('$assetsPath/$locale.json');
     }
 
     // then returns the json file
@@ -85,8 +84,7 @@ class SmartNetworkAssetLoader extends AssetLoader {
   Future<String> loadFromNetwork(String localeName) async {
     String url = localeUrl(localeName);
 
-    url = url + '' + localeName + '.json';
-
+    url = '$url$localeName.json';
     try {
       final response =
           await Future.any([http.get(Uri.parse(url)), Future.delayed(timeout)]);


### PR DESCRIPTION
The pedantic﻿ package has been deprecated, and migrating to flutter_lints﻿ is now recommended.
https://pub.dev/documentation/pedantic/latest/

The following GitHub Actions execution failures are also likely caused by that.
https://github.com/aissat/easy_localization_loader/actions/runs/17813701584/job/51136811622?pr=77


